### PR TITLE
improve recipe show

### DIFF
--- a/web/static/css/phoenix.css
+++ b/web/static/css/phoenix.css
@@ -42,12 +42,6 @@ form.link, form.button {
   padding-left: 15px;
 }
 
-/* Customize container */
-@media (min-width: 768px) {
-  .container {
-    max-width: 730px;
-  }
-}
 .container-narrow > hr {
   margin: 30px 0;
 }

--- a/web/templates/recipes/show.html.slime
+++ b/web/templates/recipes/show.html.slime
@@ -3,14 +3,22 @@
 .row
   .col-md-12
     h3.text-uppercase = @recipe.title
+.row
+  .col-md-12
     = if @recipe.cover do
       = img_tag Sandwich.Recipe.CoverUploader.url({@recipe.cover.file_name, @recipe})
-    table.table.table-striped.text-uppercase
+
+.row
+  .col-md-6
+    h5 Ingredients
+    table.table.table-striped
       = for recipe_ingredient <- @recipe.recipe_ingredients do
         tr
-          td.text-right
+          td.text-right.text-capitalize
             = recipe_ingredient.ingredient.title
           td
             - [metric_quantity, metric_unit] = quantity_in_metric(recipe_ingredient.unit, recipe_ingredient.quantity)
             = Gettext.gettext(Sandwich.Gettext, metric_unit, count: metric_quantity)
+  .col-md-6
+    h5 Instructions
     = text_to_html(@recipe.body)


### PR DESCRIPTION
divide ingredients and instructions for two columns for big screens
replace uppercase with capitalization in ingredients